### PR TITLE
Pass arguments to parsecd.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
     #! /bin/sh
     mkdir -p \$HOME/.parsec
     ln -sf $out/libexec/skel/* \$HOME/.parsec
-    exec $out/libexec/parsecd
+    exec $out/libexec/parsecd "\$@"
     EOF
     chmod +x $out/bin/parsecd
   '';


### PR DESCRIPTION
With the previous behavior, any arguments to parsecd just disappear.

Thanks for the useful nix code!