### PR TITLE
Fixed paths and hashes for latest parsec

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchurl, alsaLib, dbus, libGL, libpulseaudio, libva
+{ lib, stdenv, fetchurl, alsaLib, dbus, ffmpeg, libGL, libpulseaudio, libva
 , openssl, udev, xorg, wayland }:
 
 stdenv.mkDerivation {
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
     alsaLib (lib.getLib dbus) libGL libpulseaudio libva.out
     (lib.getLib openssl) (lib.getLib stdenv.cc.cc) (lib.getLib udev)
     xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr
-    xorg.libXScrnSaver wayland
+    xorg.libXScrnSaver wayland (lib.getLib ffmpeg)
   ];
 
   unpackPhase = ''

--- a/default.nix
+++ b/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
   # fetch the latest binaries.
   latest_appdata = fetchurl {
     url = "https://builds.parsecgaming.com/channel/release/appdata/linux/latest";
-    sha256 = "sha256-cs9b9OvS6IJ0PAO0r+XkXIHySH8DPxRdLxMH/rNJZ4k=";
+    sha256 = "sha256-fR8Wjkq4iNEQ3Ks1nssa5ii+5zHCtoym6J8sjDYCbLs=";
   };
   latest_parsecd_so = fetchurl {
     url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-83c.so";

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://builds.parsecgaming.com/package/parsec-linux.deb";
-    sha256 = "1hfdzjd8qiksv336m4s4ban004vhv00cv2j461gc6zrp37s0fwhc";
+    sha256 = "sha256-DHIH9Bk3f8NeMESKzQDYcBMArFpEk2rG2HpGjJr8zcE=";
   };
 
   # The upstream deb package is out of date and doesn't work out of the box
@@ -16,16 +16,16 @@ stdenv.mkDerivation {
   # fetch the latest binaries.
   latest_appdata = fetchurl {
     url = "https://builds.parsecgaming.com/channel/release/appdata/linux/latest";
-    sha256 = "12b796rzw1qk5xfi8gq3gx4g50awwkjszd037is85s6jxgs5pkvj";
+    sha256 = "sha256-cs9b9OvS6IJ0PAO0r+XkXIHySH8DPxRdLxMH/rNJZ4k=";
   };
   latest_parsecd_so = fetchurl {
-    url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-78.so";
-    sha256 = "0rjcrkx82dx78gz973zwvjl8zjwbj9igy6n3abimr678w4mm68nk";
+    url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-83c.so";
+    sha256 = "sha256-nzjUmF1AnBm4qye1dUygusH/THjW3zCvCLxpKIKw70o=";
   };
 
   postPatch = ''
     cp $latest_appdata usr/share/parsec/skel/appdata.json
-    cp $latest_parsecd_so usr/share/parsec/skel/parsecd-150-78.so
+    cp $latest_parsecd_so usr/share/parsec/skel/parsecd-150-83c.so
   '';
 
   runtimeDependencies = [

--- a/default.nix
+++ b/default.nix
@@ -19,13 +19,13 @@ stdenv.mkDerivation {
     sha256 = "sha256-fR8Wjkq4iNEQ3Ks1nssa5ii+5zHCtoym6J8sjDYCbLs=";
   };
   latest_parsecd_so = fetchurl {
-    url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-83c.so";
-    sha256 = "sha256-nzjUmF1AnBm4qye1dUygusH/THjW3zCvCLxpKIKw70o=";
+    url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-85c.so";
+    sha256 = "sha256-6LCg958yHYnMknIDC+GPq2HBl95sKeNQvRxuXbPIpYg=";
   };
 
   postPatch = ''
     cp $latest_appdata usr/share/parsec/skel/appdata.json
-    cp $latest_parsecd_so usr/share/parsec/skel/parsecd-150-83c.so
+    cp $latest_parsecd_so usr/share/parsec/skel/parsecd-150-85c.so
   '';
 
   runtimeDependencies = [

--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,7 @@ stdenv.mkDerivation {
 
   src = fetchurl {
     url = "https://builds.parsecgaming.com/package/parsec-linux.deb";
-    sha256 = "sha256-DHIH9Bk3f8NeMESKzQDYcBMArFpEk2rG2HpGjJr8zcE=";
+    sha256 = "sha256-wwBy86TdrHaH9ia40yh24yd5G84WTXREihR+9I6o6uU=";
   };
 
   # The upstream deb package is out of date and doesn't work out of the box
@@ -16,11 +16,11 @@ stdenv.mkDerivation {
   # fetch the latest binaries.
   latest_appdata = fetchurl {
     url = "https://builds.parsecgaming.com/channel/release/appdata/linux/latest";
-    sha256 = "sha256-fR8Wjkq4iNEQ3Ks1nssa5ii+5zHCtoym6J8sjDYCbLs=";
+    sha256 = "sha256-EEVYPLbTQlZ65yYjzmqhyArFC4EgAnM+UG8CEAPI1Vk=";
   };
   latest_parsecd_so = fetchurl {
-    url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-85c.so";
-    sha256 = "sha256-6LCg958yHYnMknIDC+GPq2HBl95sKeNQvRxuXbPIpYg=";
+    url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-86e.so";
+    sha256 = "sha256-sOZjqts+NUQyFvac+S2uMPLj6NXDcWqgcA5ITb9nXUc=";
   };
 
   postPatch = ''

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657502824,
-        "narHash": "sha256-q/56TxABu/So0mqrCiOnl9mWHC10XinFtmOHy6UeStM=",
+        "lastModified": 1673947312,
+        "narHash": "sha256-xx/2nRwRy3bXrtry6TtydKpJpqHahjuDB5sFkQ/XNDE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f904e3562aabca382d12f8471ca2330b3f82899a",
+        "rev": "2d38b664b4400335086a713a0036aafaa002c003",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
I'm not sure why the format of the hashes changed here, I just copy
pasted the hashes I saw when running `nix build`. Hopefully this is ok.