### PR TITLE
Fix/refactor: hardcoded parsecd-_.so version & missing libjpeg8, libavcodec.so.58

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
-{ lib , stdenv , fetchurl , alsaLib , dbus , ffmpeg , libGL , libpulseaudio
-, libva , jq , openssl , runCommand , udev , xorg , wayland
-}:
+{ lib, stdenv, fetchurl, alsaLib, dbus, ffmpeg_4, libGL, libpulseaudio, libva
+, jq, openssl, runCommand, udev, xorg, wayland }:
 
 stdenv.mkDerivation rec {
   pname = "parsec";
@@ -35,11 +34,10 @@ stdenv.mkDerivation rec {
   '';
 
   runtimeDependencies = [
-    curl alsaLib (lib.getLib dbus) libGL libpulseaudio libva.out
+    alsaLib (lib.getLib dbus) libGL libpulseaudio libva.out
     (lib.getLib openssl) (lib.getLib stdenv.cc.cc) (lib.getLib udev)
     xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr
-    xorg.libXScrnSaver wayland (lib.getLib ffmpeg) (lib.getLib curl)
-    (lib.getLib libpng) (lib.getLib libjpeg) (lib.getLib libXfixes)
+    xorg.libXScrnSaver wayland (lib.getLib ffmpeg_4)
   ];
 
   unpackPhase = ''

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,21 @@
-{ lib, stdenv, fetchurl, alsaLib, dbus, ffmpeg, libGL, libpulseaudio, libva
-, openssl, udev, xorg, wayland, curl, libjpeg, libpng,  libXfixes }:
+{ lib
+, stdenv
+, fetchurl
+, alsaLib
+, dbus
+, ffmpeg
+, libGL
+, libpulseaudio
+, libva
+, openssl
+, udev
+, xorg
+, wayland
+, curl
+, libjpeg
+, libpng
+, libXfixes
+}:
 
 stdenv.mkDerivation {
   pname = "parsec";
@@ -19,21 +35,37 @@ stdenv.mkDerivation {
     sha256 = "1wrzdmwp84lscmlqipdvi10l7lnisfpnrdyjg24zipkqp0rdgspa";
   };
   latest_parsecd_so = fetchurl {
-    url ="https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-90c.so";
-    sha256 = "10cbqxh4qqi63acds980ijq26y3nbqr8i2npagmlnbdfa20nknmd";
+    url = "https://builds.parsecgaming.com/channel/release/binary/linux/gz/parsecd-150-87.so";
+    sha256 = "0xfjzagdp80cvn30gd8v5jp87ba83lqcjcc5kqwm6jdi6vxagp0q";
   };
 
   postPatch = ''
     cp $latest_appdata usr/share/parsec/skel/appdata.json
-    cp $latest_parsecd_so usr/share/parsec/skel/parsecd-150-85c.so
+    cp $latest_parsecd_so usr/share/parsec/skel/parsecd-150-87.so
   '';
 
   runtimeDependencies = [
-    curl alsaLib (lib.getLib dbus) libGL libpulseaudio libva.out
-    (lib.getLib openssl) (lib.getLib stdenv.cc.cc) (lib.getLib udev)
-    xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr
-    xorg.libXScrnSaver wayland (lib.getLib ffmpeg) (lib.getLib curl) (lib.getLib libpng) 
-    (lib.getLib libjpeg) (lib.getLib libXfixes)
+    curl
+    alsaLib
+    (lib.getLib dbus)
+    libGL
+    libpulseaudio
+    libva.out
+    (lib.getLib openssl)
+    (lib.getLib stdenv.cc.cc)
+    (lib.getLib udev)
+    xorg.libX11
+    xorg.libXcursor
+    xorg.libXi
+    xorg.libXinerama
+    xorg.libXrandr
+    xorg.libXScrnSaver
+    wayland
+    (lib.getLib ffmpeg)
+    (lib.getLib curl)
+    (lib.getLib libpng)
+    (lib.getLib libjpeg)
+    (lib.getLib libXfixes)
   ];
 
   unpackPhase = ''

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,13 @@
-{ lib, stdenv, fetchurl, alsaLib, dbus, ffmpeg_4, libGL, libpulseaudio, libva
-, jq, openssl, runCommand, udev, xorg, wayland }:
+{ lib, stdenv, fetchurl, alsaLib, curl, dbus, ffmpeg_4, libGL, libpulseaudio,
+  libpng, libva, jq, openssl, runCommand, udev, xorg, wayland }:
 
 stdenv.mkDerivation rec {
   pname = "parsec";
-  version = "2021-01-12";
+  version = "150-90c";
 
   src = fetchurl {
     url = "https://builds.parsecgaming.com/package/parsec-linux.deb";
-    sha256 = "1gak01lxbi88zddvywkapvqwxk6a7xyqlfdcix0f57k0n2brsm5c";
+    sha256 = "sha256-rFSdl7BgnuJAj6w5in0/yszO8b5qcr9b+wjF1WkAU70=";
   };
 
   # The upstream deb package is out of date and doesn't work out of the box
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   # fetch the latest binaries.
   latest_appdata = fetchurl {
     url = "https://builds.parsecgaming.com/channel/release/appdata/linux/latest";
-    sha256 = "1wrzdmwp84lscmlqipdvi10l7lnisfpnrdyjg24zipkqp0rdgspa";
+    sha256 = "sha256-6urXMrh43viJeNK3bK/T0dJDQYi73YhpZZoSdHltP/M=";
   };
 
   latest_parsecd_so = runCommand "latest_parsecd_so" { } ''
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   parsecd_so = fetchurl {
     url = "https://builds.parsecgaming.com/channel/release/binary/linux/gz/${builtins.readFile latest_parsecd_so}";
-    sha256 = "0xfjzagdp80cvn30gd8v5jp87ba83lqcjcc5kqwm6jdi6vxagp0q";
+    sha256 = "sha256-rdppgVCuLUvrU9eKiDJedngjsIwAJd2YGiZiTGDHi4E=";
   };
 
   postPatch = ''
@@ -33,11 +33,23 @@ stdenv.mkDerivation rec {
     cp $parsecd_so usr/share/parsec/skel/${builtins.readFile latest_parsecd_so}
   '';
 
+  libjpeg8 = stdenv.mkDerivation (finalAttrs: {
+    pname = "libjpeg";
+    version = "8";
+
+    src = fetchurl {
+      url = "http://www.ijg.org/files/jpegsrc.v8.tar.gz";
+      sha256 = "sha256-F7qlt6yz8PjRXXPdJBbLk5ilWzM0pak1nSeNjealC6w=";
+    };
+
+    outputs = [ "out" "lib" ];
+  });
+
   runtimeDependencies = [
-    alsaLib (lib.getLib dbus) libGL libpulseaudio libva.out
-    (lib.getLib openssl) (lib.getLib stdenv.cc.cc) (lib.getLib udev)
-    xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr
-    xorg.libXScrnSaver wayland (lib.getLib ffmpeg_4)
+    alsaLib (lib.getLib dbus) (lib.getLib curl) (lib.getLib libjpeg8.lib)
+    libGL libpulseaudio libpng libva (lib.getLib openssl) (lib.getLib stdenv.cc.cc)
+    (lib.getLib udev) xorg.libX11 xorg.libXcursor xorg.libXfixes xorg.libXi xorg.libXinerama
+    xorg.libXrandr xorg.libXScrnSaver wayland (lib.getLib ffmpeg_4)
   ];
 
   unpackPhase = ''


### PR DESCRIPTION
Hey, thanks for the great package!

I tried running your latest changes but `parsecd` was exiting without an explanation, so I ran:
```
$ strace parsecd
...
stat("/home/james/.parsec//appdata.json", {st_mode=S_IFREG|0555, st_size=149, ...}) = 0
openat(AT_FDCWD, "/home/james/.parsec//appdata.json", O_RDONLY) = 4
newfstatat(4, "", {st_mode=S_IFREG|0555, st_size=149, ...}, AT_EMPTY_PATH) = 0
read(4, "{\n    \"entry_symbol\": \"wx_main\","..., 4096) = 149
close(4)                                = 0
stat("/home/james/.parsec//parsecd-150-87.so", 0x7ffe36e1f910) = -1 ENOENT (No such file or directory)
exit_group(2)                           = ?
+++ exited with 2 +++
```
which showed that `~/.parsec/parsecd-150-87.so` wasn't available.

I fixed it by just [bumping the hardcoded](https://github.com/DarthPJB/parsec-gaming-nix/commit/3cc0e53c171fd416d37531e84cd130b89ef7a147) `so` versions, and then took it further by reading the `so` filename [from the `latest_appdata` response](https://github.com/DarthPJB/parsec-gaming-nix/commit/a8f5719ea199ba1f9407b888fe0e54119c088448).

Feel free to merge either/both/neither of the commits :D

<details><summary>Tested by running:</summary>
<p>

```bash
./parsec-gaming-nix $ ls ~/.parsec/
ls: cannot access '/home/james/.parsec/': No such file or directory

./parsec-gaming-nix $ nix shell
./parsec-gaming-nix $ parsecd // fails silently
./parsec-gaming-nix $ ls ~/.parsec/
appdata.json  parsecd-150-85c.so  parsecd-150-86e.so

./parsec-gaming-nix $ rm -r ~/.parsec

// apply fix

./parsec-gaming-nix $ nix shell
./parsec-gaming-nix $ parsecd // succeeds

./parsec-gaming-nix $ ls ~/.parsec/
appdata.json  config.txt  devid.bin  hotkey.json  lock  log.txt  parsecd-150-87.so
```
</p>
</details>

