### PR TITLE
Automatic updates of parsec inputs with flakes and github actions

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -34,6 +34,7 @@ jobs:
                     git push origin "$branch_name"
                     git checkout "$original_branch"
                     git merge "$branch_name" --no-ff -m "Merge branch '$branch_name' into '$original_branch'"
+                    git push origin "$original_branch"
                 else
                     echo "No changes to commit."
                 fi

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,37 @@
+name: Update flake.lock
+
+on:
+    workflow_dispatch:
+    schedule:
+        - cron: '0 0 * * 0'
+
+jobs:
+    update-flake-lock:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up Nix
+              uses: cachix/install-nix-action@v31
+              with:
+                  extra_nix_config: |
+                      experimental-features = nix-command flakes
+            - name: Update flake.lock
+              run: nix flake update parsecDeb parsecMeta
+            - name: Commit and push changes
+              run: |
+                # Check if there are changes to commit
+                if [[ -n $(git status --porcelain) ]]; then
+                    git config --global user.name 'github-actions'
+                    git config --global user.email 'github-actions@github.com'
+                    branch_name="update-flake-lock-$(date +'%Y-%m-%d')"
+                    git checkout -b "$branch_name"
+                    git add flake.lock
+                    git commit -m "Update flake.lock on $(date +'%Y-%m-%d')"
+                    git push origin "$branch_name"
+                    git checkout main
+                    git merge "$branch_name" --no-ff -m "Merge branch '$branch_name' into main"
+                else
+                    echo "No changes to commit."
+                fi

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -11,6 +11,13 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4
+            
+            - name: Stop if not on main branch
+              run: |
+                if [[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]]; then
+                    echo "This workflow only runs on the main branch."
+                    exit 0
+                fi
 
             - name: Set up Nix
               uses: cachix/install-nix-action@v31

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -27,12 +27,13 @@ jobs:
                     git config --global user.name 'github-actions'
                     git config --global user.email 'github-actions@github.com'
                     branch_name="update-flake-lock-$(date +'%Y-%m-%d')"
+                    original_branch=$(git rev-parse --abbrev-ref HEAD)
                     git checkout -b "$branch_name"
                     git add flake.lock
                     git commit -m "Update flake.lock on $(date +'%Y-%m-%d')"
                     git push origin "$branch_name"
-                    git checkout main
-                    git merge "$branch_name" --no-ff -m "Merge branch '$branch_name' into main"
+                    git checkout "$original_branch"
+                    git merge "$branch_name" --no-ff -m "Merge branch '$branch_name' into '$original_branch'"
                 else
                     echo "No changes to commit."
                 fi

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -4,6 +4,7 @@ on:
     workflow_dispatch:
     schedule:
         - cron: '0 0 * * 0'
+    push:
 
 jobs:
     update-flake-lock:

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -4,7 +4,6 @@ on:
     workflow_dispatch:
     schedule:
         - cron: '0 0 * * 0'
-    push:
 
 jobs:
     update-flake-lock:

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -26,7 +26,7 @@ jobs:
                 if [[ -n $(git status --porcelain) ]]; then
                     git config --global user.name 'github-actions'
                     git config --global user.email 'github-actions@github.com'
-                    branch_name="update-flake-lock-$(date +'%Y-%m-%d')"
+                    branch_name="update-flake-lock-$(date +'%Y-%m-%d-%H-%M-%S')"
                     original_branch=$(git rev-parse --abbrev-ref HEAD)
                     git checkout -b "$branch_name"
                     git add flake.lock

--- a/default.nix
+++ b/default.nix
@@ -1,36 +1,35 @@
-{ lib, stdenv, fetchurl, alsaLib, curl, dbus, ffmpeg_4, libGL, libpulseaudio,
-  libpng, libva, jq, openssl, runCommand, udev, xorg, wayland }:
+{ lib, stdenv, fetchurl, alsa-lib, curl, dbus, ffmpeg_4, libGL, libpulseaudio,
+  libpng, libva, jq, openssl, runCommand, udev, xxd, xorg, wayland, parsecDeb, parsecMeta }:
 
-stdenv.mkDerivation rec {
+let
+  parsecdSoName = builtins.readFile ( runCommand "latest_parsecd_so" { } ''
+    cat ${parsecMeta} | ${jq}/bin/jq --raw-output .so_name | tee $out
+  '');
+
+  parsecdSoHash = builtins.readFile ( runCommand "latest_parsecd_so_hash" { } ''
+    hex=$(cat ${parsecMeta} | ${jq}/bin/jq --raw-output .hash)
+    echo "$hex" | ${xxd}/bin/xxd -r -p | base64 | tr -d '\n' > $out
+  '');
+
+  parsecdSo = fetchurl {
+    url = "https://builds.parsecgaming.com/channel/release/binary/linux/gz/${parsecdSoName}";
+    sha256 = "sha256-${parsecdSoHash}";
+  };
+  a = stdenv.mkDerivation rec {
   pname = "parsec";
   version = "150-90c";
 
-  src = fetchurl {
-    url = "https://builds.parsecgaming.com/package/parsec-linux.deb";
-    sha256 = "sha256-rFSdl7BgnuJAj6w5in0/yszO8b5qcr9b+wjF1WkAU70=";
-  };
+  src = parsecDeb;
 
   # The upstream deb package is out of date and doesn't work out of the box
   # anymore due to api.parsecgaming.com being down. Auto-updating doesn't work
   # because it doesn't patchelf the dynamic dependencies. Instead, "manually"
   # fetch the latest binaries.
-  latest_appdata = fetchurl {
-    url = "https://builds.parsecgaming.com/channel/release/appdata/linux/latest";
-    sha256 = "sha256-6urXMrh43viJeNK3bK/T0dJDQYi73YhpZZoSdHltP/M=";
-  };
 
-  latest_parsecd_so = runCommand "latest_parsecd_so" { } ''
-    cat ${latest_appdata} | ${jq}/bin/jq --raw-output .so_name | tee $out
-  '';
-
-  parsecd_so = fetchurl {
-    url = "https://builds.parsecgaming.com/channel/release/binary/linux/gz/${builtins.readFile latest_parsecd_so}";
-    sha256 = "sha256-rdppgVCuLUvrU9eKiDJedngjsIwAJd2YGiZiTGDHi4E=";
-  };
 
   postPatch = ''
-    cp $latest_appdata usr/share/parsec/skel/appdata.json
-    cp $parsecd_so usr/share/parsec/skel/${builtins.readFile latest_parsecd_so}
+    cp ${parsecMeta} usr/share/parsec/skel/appdata.json
+    cp ${parsecdSo} usr/share/parsec/skel/${parsecdSoName}
   '';
 
   libjpeg8 = stdenv.mkDerivation (finalAttrs: {
@@ -46,7 +45,7 @@ stdenv.mkDerivation rec {
   });
 
   runtimeDependencies = [
-    alsaLib (lib.getLib dbus) (lib.getLib curl) (lib.getLib libjpeg8.lib)
+    alsa-lib (lib.getLib dbus) (lib.getLib curl) (lib.getLib libjpeg8.lib)
     libGL libpulseaudio libpng libva (lib.getLib openssl) (lib.getLib stdenv.cc.cc)
     (lib.getLib udev) xorg.libX11 xorg.libXcursor xorg.libXfixes xorg.libXi xorg.libXinerama
     xorg.libXrandr xorg.libXScrnSaver wayland (lib.getLib ffmpeg_4)
@@ -92,4 +91,5 @@ stdenv.mkDerivation rec {
     license = licenses.unfree;
     maintainers = with maintainers; [ delroth ];
   };
-}
+};
+in a

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,35 @@
         "type": "github"
       }
     },
+    "parsecDeb": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-+sNEGgb2wARM8JDf3Gdzk+N/IFNERlEQJFROGQGP8XE=",
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/package/parsec-linux.deb"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/package/parsec-linux.deb"
+      }
+    },
+    "parsecMeta": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-lP2Mc0/gVWM6X/79/xB0ncMj5vXUjtk+QTVC/z9/MaQ=",
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/channel/release/appdata/linux/latest"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/channel/release/appdata/linux/latest"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "parsecDeb": "parsecDeb",
+        "parsecMeta": "parsecMeta"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,49 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684242266,
-        "narHash": "sha256-uaCQ2k1bmojHKjWQngvnnnxQJMY8zi1zq527HdWgQf8=",
+        "lastModified": 1749857119,
+        "narHash": "sha256-tG5xUn3hFaPpAHYIvr2F88b+ovcIO5k1HqajFy7ZFPM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e0743a5aea1dc755d4b761daf75b20aa486fdad",
+        "rev": "5f4f306bea96741f1588ea4f450b2a2e29f42b98",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "parsecDeb": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-+sNEGgb2wARM8JDf3Gdzk+N/IFNERlEQJFROGQGP8XE=",
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/package/parsec-linux.deb"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/package/parsec-linux.deb"
+      }
+    },
+    "parsecMeta": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-lP2Mc0/gVWM6X/79/xB0ncMj5vXUjtk+QTVC/z9/MaQ=",
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/channel/release/appdata/linux/latest"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://builds.parsecgaming.com/channel/release/appdata/linux/latest"
       }
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "parsecDeb": "parsecDeb",
+        "parsecMeta": "parsecMeta"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -16,35 +16,9 @@
         "type": "github"
       }
     },
-    "parsecDeb": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-+sNEGgb2wARM8JDf3Gdzk+N/IFNERlEQJFROGQGP8XE=",
-        "type": "file",
-        "url": "https://builds.parsecgaming.com/package/parsec-linux.deb"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://builds.parsecgaming.com/package/parsec-linux.deb"
-      }
-    },
-    "parsecMeta": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-lP2Mc0/gVWM6X/79/xB0ncMj5vXUjtk+QTVC/z9/MaQ=",
-        "type": "file",
-        "url": "https://builds.parsecgaming.com/channel/release/appdata/linux/latest"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://builds.parsecgaming.com/channel/release/appdata/linux/latest"
-      }
-    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "parsecDeb": "parsecDeb",
-        "parsecMeta": "parsecMeta"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,21 @@
 {
-  outputs = { self, nixpkgs }:
+	inputs = {
+		nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+		parsecDeb = {
+			url = "https://builds.parsecgaming.com/package/parsec-linux.deb";
+			flake = false;
+		};
+		parsecMeta = {
+			url = "https://builds.parsecgaming.com/channel/release/appdata/linux/latest";
+			flake = false;
+		};
+	};
+
+  outputs = { self, nixpkgs, parsecDeb, parsecMeta }:
 	{
 	    # Declare some local packages be available via self.packages
 	    packages.x86_64-linux = let pkgs = import nixpkgs { system = "x86_64-linux"; config.allowUnfree = true; }; in {
-	     parsecgaming = pkgs.callPackage ./. {};
+	     parsecgaming = pkgs.callPackage ./. { inherit parsecMeta parsecDeb; };
 	 };
   defaultPackage.x86_64-linux = self.packages.x86_64-linux.parsecgaming;
 };

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
 	    # Declare some local packages be available via self.packages
 	    packages.x86_64-linux = let pkgs = import nixpkgs { system = "x86_64-linux"; config.allowUnfree = true; }; in {
 	     parsecgaming = pkgs.callPackage ./. { inherit parsecMeta parsecDeb; };
+
 	 };
   defaultPackage.x86_64-linux = self.packages.x86_64-linux.parsecgaming;
 };


### PR DESCRIPTION
This PR proposes following 3 changes.

1. Moved all parsec related hash locks to flake.lock
2. Reading sha256 of parsecd_so from `https://builds.parsecgaming.com/channel/release/appdata/linux/latest` instead of hard-coding it.
3. Added weekly gh actions to update hashes in flake.lock. (successful job example: https://github.com/comavius/parsec-gaming-nix/actions/runs/15683775439/job/44181600813)

Please note that this PR has breaking changes.